### PR TITLE
Add the wgo emacs support file I linked in IRC a few days back.

### DIFF
--- a/editors/emacs.el
+++ b/editors/emacs.el
@@ -1,0 +1,24 @@
+;; Experimental wgo support for EMACS.
+;; Allows go-mode and other go tools to be able to handle the
+;; GOPATH changes that wgo does when they shell out to go for stuff.
+;; To use, add (load-file "/path/to/this/file.el") to your emacs config.
+
+(defun setup-go-mode-env ()
+  (make-local-variable 'process-environment)
+  (let ((val (shell-command-to-string "wgo env GOPATH")))
+    (if (not (string= val "no workspace"))
+	(setenv "GOPATH" val)
+      )
+    )
+  )
+
+(add-hook 'go-mode 'setup-go-mode-env)
+
+(defun her-apply-function (orig-fun name)
+  (let ((res (funcall orig-fun name)))
+    (if (or (string= name "*gocode*") (string= name "*compilation*"))
+	(setup-go-mode-env)
+      )
+    res))
+
+(advice-add 'generate-new-buffer :around #'her-apply-function)


### PR DESCRIPTION
This, assuming no major bugs, allows emacs packages such as go-mode and go-autocomplete to be able to handle the way that wgo changes the GOPATH.

It does this by changing the environment to be buffer-local, and then setting the GOPATH based on the execution result of `wgo env GOPATH`
